### PR TITLE
Use width and height instead of density.

### DIFF
--- a/ConvertImage/ImageProcessor.cs
+++ b/ConvertImage/ImageProcessor.cs
@@ -49,10 +49,15 @@ namespace ConvertImage
             // uses Magick.Net (The .NET wrapper for the ImageMagick library)
             // URL: https://magick.codeplex.com/
             //
+
+            int w = Convert.ToInt32(width);
+            int h = Convert.ToInt32(height);
+            int magnification = 3;
+
             //convert the image here
             MagickReadSettings settings = new MagickReadSettings();
-            // Settings the density to 600 dpi will create an image with a better quality
-            settings.Density = new Density(600);
+            settings.Width = magnification * w;
+            settings.Height = magnification * h;
 
             // if we are going to resize the image then we need to
             // set OpenCL.IsEnabled = false to resolve the driver related issues;
@@ -62,7 +67,7 @@ namespace ConvertImage
             {
                 //resize the image
                 //When zero is specified for the height, the height will be calculated with the aspect ratio.
-                image.Resize(Convert.ToInt32(width), Convert.ToInt32(height));
+                image.Resize(w, h);
 
                 // Save as jpg/gif
                 image.Write(Path.Combine(outputDirectory, $"{imageFilename}.gif"));

--- a/ConvertImage/ImageProcessor.cs
+++ b/ConvertImage/ImageProcessor.cs
@@ -36,16 +36,10 @@ namespace ConvertImage
             imgHeight = "830";
             Stopwatch s = new Stopwatch();
             s.Start();
-            List<Task> runningTasks = new List<Task>();
-            foreach (string fileStr in Directory.GetFiles(pptImageFolder, "*.EMF"))
+            Parallel.ForEach(Directory.GetFiles(pptImageFolder, "*.EMF"), (string fileStr) =>
             {
-                runningTasks.Add(Task.Factory.StartNew(new Action(() =>
-                {
-                    ConvertImage(fileStr, imgWidth, imgHeight, pptImageFolder, Path.GetFileNameWithoutExtension(fileStr).ToLower());
-                })));
-
-            }
-            Task.WaitAll(runningTasks.ToArray());
+              ConvertImage(fileStr, imgWidth, imgHeight, pptImageFolder, Path.GetFileNameWithoutExtension(fileStr).ToLower());
+            });
             s.Stop();
             Console.WriteLine(s.ElapsedMilliseconds);
         }

--- a/ConvertImage/Program.cs
+++ b/ConvertImage/Program.cs
@@ -14,8 +14,8 @@ namespace ConvertImage
         static void Main(string[] args)
         {
             ImageProcessor imgProcessor = new ImageProcessor();
-            imgProcessor.ProcessImages(Environment.CurrentDirectory);
-            //imgProcessor.ProcessImagesMultiThreaded(Environment.CurrentDirectory);
+            //imgProcessor.ProcessImages(Environment.CurrentDirectory);
+            imgProcessor.ProcessImagesMultiThreaded(Environment.CurrentDirectory);
         }        
     }
 }


### PR DESCRIPTION
EMF images are vector images so that is why you need to set the density to get a high quality image. But with the EMF format there is an extra feature. You can set the width and height to the desired size. The only issue with that is that you will get a better quality image when you set it to a bigger size and resize it afterwards. I gave it a couple tries and with a magnification of 3 I would get almost the same image as when you use 600 DPI. But it created the output images 10 times faster. You might need to increase that value for your other images. I had no issues when doing this multi threaded.